### PR TITLE
Fix: Ignore xmlns

### DIFF
--- a/src/UniversalDiveDataFormat.Tests/Services/UddfDeserialiserTests.cs
+++ b/src/UniversalDiveDataFormat.Tests/Services/UddfDeserialiserTests.cs
@@ -184,5 +184,18 @@ public class UddfDeserialiserTests
 			Image image = _uddfDeserialiser.Deserialise<Image>(xml);
 			image.Id.ShouldBe("img_flatfeet");
 			image.ObjectName.ShouldBe("flatfeet.jpg");
-		}	
+		}
+		
+		[Fact]
+		public void CanDeserialiseWithNamespace()
+		{
+			const string xml = """
+								<uddf version="3.2.0" xmlns="http://www.streit.cc/uddf/3.2/">
+									<mediadata>
+
+									</mediadata>
+								</uddf>
+								""";
+			Should.NotThrow(() => _uddfDeserialiser.Deserialise<UniversalDiveDataFormatRoot>(xml));
+		}
 }

--- a/src/UniversalDiveDataFormat/Services/NamespaceIgnorantXmlTextReader.cs
+++ b/src/UniversalDiveDataFormat/Services/NamespaceIgnorantXmlTextReader.cs
@@ -1,0 +1,12 @@
+using System.Xml;
+
+namespace UniversalDiveDataFormat.Services;
+
+// This is needed because not all sources set the xmlns correctly
+public class NamespaceIgnorantXmlTextReader : XmlTextReader
+{
+	public NamespaceIgnorantXmlTextReader(TextReader reader): base(reader) { }
+	public NamespaceIgnorantXmlTextReader(Stream stream): base(stream) { }
+
+	public override string NamespaceURI => string.Empty;
+}

--- a/src/UniversalDiveDataFormat/Services/UddfDeserialiser.cs
+++ b/src/UniversalDiveDataFormat/Services/UddfDeserialiser.cs
@@ -1,3 +1,4 @@
+using System.Xml;
 using System.Xml.Serialization;
 using UniversalDiveDataFormat.Models;
 
@@ -6,6 +7,7 @@ namespace UniversalDiveDataFormat.Services;
 public class UddfDeserialiser: IUddfDeserialiser
 {
 	private readonly LinkResolutionService _linkResolutionService;
+
 	public UddfDeserialiser(LinkResolutionService linkResolutionService)
 	{
 		_linkResolutionService = linkResolutionService;
@@ -16,7 +18,9 @@ public class UddfDeserialiser: IUddfDeserialiser
 	public T Deserialise<T>(TextReader reader) where T : UddfModel
 	{
 		XmlSerializer serializer = new(typeof(T));
-		T obj = (T)serializer.Deserialize(reader)!; // This should throw if the xml is invalid
+		XmlReader xmlReader = new NamespaceIgnorantXmlTextReader(reader);
+		
+		T obj = (T)serializer.Deserialize(xmlReader)!; // This should throw if the xml is invalid
 		_linkResolutionService.ResolveAllLinksInObjectGraph(obj);
 		return obj;
 	}
@@ -24,7 +28,9 @@ public class UddfDeserialiser: IUddfDeserialiser
 	public T Deserialise<T>(Stream stream) where T : UddfModel
 	{
 		XmlSerializer serializer = new(typeof(T));
-		T obj = (T)serializer.Deserialize(stream)!; // This should throw if the xml is invalid
+		XmlReader xmlReader = new NamespaceIgnorantXmlTextReader(stream);
+
+		T obj = (T)serializer.Deserialize(xmlReader)!; // This should throw if the xml is invalid
 		_linkResolutionService.ResolveAllLinksInObjectGraph(obj);
 		return obj;
 	}


### PR DESCRIPTION
Not all UDDF sources set this correctly or at all, so let's just ignore it.